### PR TITLE
修改HiMCBBS备案和状态信息

### DIFF
--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -368,10 +368,10 @@ const db_forums = [
     {
         title: "Hi世界Minecraft论坛",
         url: "https://himcbbs.com/",
-        state: "failure",
+        state: "up",
         createdAt: "2024/01/28",
-        updatedAt: "2024/03/16",
-        hasICP: "in_progress",
+        updatedAt: "2024/03/20",
+        hasICP: "yes",
         hasNetSec: "no",
         note: "非大陆服务器，主营Java版，含基岩版。",
         reference: [


### PR DESCRIPTION
备案的是himcbbs.net域名，还没加解析
有一些准备工作，开始用的时候就再替换一下