### PR TITLE
增加展开参考资料的功能

### DIFF
--- a/res/class/DOMConstructor.js
+++ b/res/class/DOMConstructor.js
@@ -98,7 +98,7 @@ class DOMForumList {
     static itemEx(item) {
         item = {
             title: "未命名",
-            url: "https://www.example.com/",
+            url: "https://www.example.com",
             archiveUrl: "",
             updatedAt: "1970/01/01",
             note: "",
@@ -173,8 +173,10 @@ class DOMForumList {
     static referenceList(referenceItems) {
         if (!Array.isArray(referenceItems) || referenceItems.length <= 0) return '';
         let dom = '<ol>';
-        referenceItems.forEach(e => {
+        const medianRow = 2;
+        referenceItems.forEach((e, index) => {
             dom += DOMForumList.reference(e);
+            if (index + 1 == medianRow && referenceItems.length > medianRow) dom += `</ol><details><summary> 查看更多....</summary><ol class="reference-more" start="${medianRow + 1}">`;
         });
         return dom + '</ol>';
     }

--- a/res/script/common.js
+++ b/res/script/common.js
@@ -98,6 +98,10 @@ $(document).on('click', '.list-controller-item.close', function() {
     $('#' + $(this).data('target') + ' .forum-item-content').removeClass('active');
 });
 
+$(document).on('click', '.forum-item-content summary', function() {
+    this.style.display = 'none';
+});
+
 $(document).on('click', 'nav .nav-item', function() {
     const target = $(this).data('target');
     scrollToTitle(target);

--- a/res/style/common.css
+++ b/res/style/common.css
@@ -476,8 +476,27 @@ nav.in-sticky {
     padding: 0.25rem 1rem 0.75rem 1rem;
 }
 
+.forum-item-content summary {
+    margin-top: 0.25rem;
+    color: var(--ant-color-primary);
+    display: inline-block;
+    cursor: pointer;
+}
+
+.forum-item-content summary:hover {
+    color: var(--ant-color-primary-text-hover);
+}
+
+.forum-item-content summary:active {
+    color: var(--ant-color-primary-text-active);
+}
+
 .forum-item-content ol {
     padding-left: 1rem;
+}
+
+.forum-item-content ol.reference-more li {
+    margin-top: 0.5rem;
 }
 
 .forum-item-content ol li+li {


### PR DESCRIPTION
目前显示为 `查看更多....`，默认设置为参考资料大于2项时将会折叠。

示例图：

![image](https://github.com/LYOfficial/BBSPK/assets/144581741/962c3dff-cdc3-4b96-b931-8233816810a0)