### PR TITLE
请求删除“我的世界铁路中文社区”“我的世界铁路中文论坛”“氧气社区”的链接

### DIFF
--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -183,17 +183,6 @@ const db_forums = [
         reference: []
     },
     {
-        title: "我的世界铁路中文社区",
-        url: "https://www.mtrbbs.com.cn",
-        state: "up",
-        createdAt: "2022/02/26",
-        updatedAt: "2024/04/06",
-        hasICP: "no",
-        hasNetSec: "no",
-        note: "非大陆服务器。",
-        reference: [] 
-    },
-    {
         title: "我的世界UTC论坛",
         url: "https://bbs.mcutc.cn",
         state: "up",
@@ -250,17 +239,6 @@ const db_forums = [
         ]
     },
     {
-        title: "我的世界铁路中文论坛",
-        url: "https://www.mtrbbs.top",
-        state: "up",
-        createdAt: "2022/05/15",
-        updatedAt: "2024/04/06",
-        hasICP: "no",
-        hasNetSec: "no",
-        note: "非大陆服务器。",
-        reference: []
-    },
-    {
         title: "MineTalk",
         url: "https://www.minebox.store",
         state: "up",
@@ -303,17 +281,6 @@ const db_forums = [
                 url: "https://www.bilibili.com/video/BV1J1421U7z2/"
             }
         ]
-    },
-    {
-        title: "氧气社区",
-        url: "https://bbs.oxygenstudio.cn",
-        state: "up",
-        createdAt: "2022/07/25",
-        updatedAt: "2024/04/06",
-        hasICP: "yes",
-        hasNetSec: "no",
-        note: "",
-        reference: [] 
     },
     {
         title: "像素世界论坛",


### PR DESCRIPTION
删除这三个站点的原因十分简单：他们和 MCBBS 完全不同

* “我的世界铁路中文社区”“我的世界铁路中文论坛”只专注于 [MTRmod （Minecraft Transit Railway）](https://www.mcmod.cn/class/2157.html)的内容
* ”氢气社区“仅仅是三个服务器（氢气工艺 HydCraft、	Cloudsdale、瀚海工艺 Vastsea）的自有论坛

由于已经引起一部分使用这三个站点的用户的反感，还请尽快删除