### PR TITLE
两个论坛更改信息

### DIFF
--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -323,10 +323,9 @@ const db_forums = [
     {
         title: "萝卜我的世界论坛",
         url: "https://www.luobomc.top",
-        state: "close",
+        state: "up",
         createdAt: "2022/08/28",
-        closedAt: "2024/03/29",
-        updatedAt: "2024/06/09",
+        updatedAt: "2024/08/25",
         hasICP: "no",
         hasNetSec: "no",
         note: "非大陆服务器。",

--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -450,6 +450,17 @@ const db_forums = [
         ]
     },
     {
+        title: "ikunmc",
+        url: "https://www.ikunmc.com",
+        state: "up",
+        createdAt: "2023/08/01",
+        updatedAt: "2024/08/25",
+        hasICP: "no",
+        hasNetSec: "no",
+        note: "非大陆服务器。",
+        reference: []
+    },
+    {
         title: "HiMCBBS",
         url: "https://www.himcbbs.com",
         state: "up",
@@ -462,17 +473,6 @@ const db_forums = [
             {
                 title: "我要做一个可以平替MCBBS的论坛！！！快来加入我们吧~",
                 url: "https://www.bilibili.com/video/BV1n2421M7yt/"
-            },
-            {
-        title: "ikunmc",
-        url: "https://www.ikunmc.com",
-        state: "up",
-        createdAt: "2023/08/01",
-        updatedAt: "2024/08/25",
-        hasICP: "no",
-        hasNetSec: "no",
-        note: "非大陆服务器。",
-        reference: []
             },
             {
                 title: "一个可以替代MCBBS的网站！",

--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -464,6 +464,17 @@ const db_forums = [
                 url: "https://www.bilibili.com/video/BV1n2421M7yt/"
             },
             {
+        title: "ikunmc",
+        url: "https://www.ikunmc.com",
+        state: "up",
+        createdAt: "2023/08/01",
+        updatedAt: "2024/08/25",
+        hasICP: "no",
+        hasNetSec: "no",
+        note: "非大陆服务器。",
+        reference: []
+            },
+            {
                 title: "一个可以替代MCBBS的网站！",
                 url: "https://www.bilibili.com/video/BV13r42187th/"
             },
@@ -496,17 +507,6 @@ const db_forums = [
                 url: "https://www.bilibili.com/video/BV1nA4m1F7tN/"
             }
         ]
-    },
-    {
-        title: "ikunmc",
-        url: "https://www.ikunmc.com",
-        state: "up",
-        createdAt: "2023/10/28",
-        updatedAt: "2024/07/26",
-        hasICP: "no",
-        hasNetSec: "no",
-        note: "非大陆服务器。",
-        reference: []
     },
     {
         title: "SimpBBS",


### PR DESCRIPTION
萝卜我的世界论坛 收到邮件通知，已恢复

ikunmc 论坛真正创建的时间为2024/08/01，此前一直使用 mc.爱坤.cn（mc.xn--tfsp73d.cn）作为域名
以下是 Discuz 应用中心的信息
![IMG_20240825_125546](https://github.com/user-attachments/assets/df8d92d0-85a4-41fc-ad18-0fc14cb883e2)
