### PR TITLE
更新 MCBBSV50纪念站域名

### DIFF
--- a/res/data/forums.js
+++ b/res/data/forums.js
@@ -1275,9 +1275,9 @@ const db_forums_ex = [
     },
     {
         title: "MCBBSv50纪念站",
-        url: "https://v50.mcbbs.rip/",
+        url: "https://mcbbs.sbs/",
         archiveUrl: "https://web.archive.org/web/20240609005306/https://v50.mcbbs.rip/",
-        updatedAt: "2024/06/09",
+        updatedAt: "2024/10/15",
         note: "v我50，复活牢坛",
         reference: []
     }


### PR DESCRIPTION
https://mcbbs.sbs/forum.php?mod=viewthread&tid=1383
根据该贴回复，v50的域名已无法使用，故更新其它域名